### PR TITLE
Vector endpoint + tenant_id for uptracloki

### DIFF
--- a/example/zerolog-vector/vector.toml
+++ b/example/zerolog-vector/vector.toml
@@ -13,7 +13,9 @@
 [sinks.cloki]
 type = "loki"
 inputs = [ "in" ]
-endpoint = "http://localhost:3100"
+endpoint = "http://localhost:14317/1"
+tenant_id = "https://project1_secret_token@localhost/1"
+
 
   [sinks.cloki.labels]
   forwarder = "vector"


### PR DESCRIPTION
Not sure why the example doesn't feature it, but it would be required in the current architecture