### PR TITLE
fix: opentelemetry exit condition

### DIFF
--- a/uptrace/uptrace.go
+++ b/uptrace/uptrace.go
@@ -27,7 +27,7 @@ func ConfigureOpentelemetry(opts ...Option) {
 	ctx := context.TODO()
 	cfg := newConfig(opts)
 
-	if !cfg.tracingEnabled && cfg.metricsEnabled {
+	if !cfg.tracingEnabled && !cfg.metricsEnabled {
 		return
 	}
 


### PR DESCRIPTION
`configureOpentelemetry` should exit early only when both tracing and metrics are disabled.